### PR TITLE
Numpy type fixes

### DIFF
--- a/epidemix/epidemic.py
+++ b/epidemix/epidemic.py
@@ -44,11 +44,11 @@ class EpiModel(object):
         # Assign each node to ...
         for i, state in enumerate(self.initial):
             # ... diff state represented by a number.
-            states[state.astype(np.bool)] = i
+            states[state.astype(bool)] = i
 
         # Summarize the state and color of each node to an independent arr.
-        self.state_list = self.state_queue[states.astype(np.int)]
-        self.color_list = self.state_colors[states.astype(np.int)]
+        self.state_list = self.state_queue[states.astype(int)]
+        self.color_list = self.state_colors[states.astype(int)]
 
         # Assign the initial information to the node attribute.
         self.G = self.set_graph(self.state_list,

--- a/epidemix/equations.py
+++ b/epidemix/equations.py
@@ -66,7 +66,7 @@ class NetworkODE(object):
         return self.N * vec / np.sum(vec)
 
     def inv_idx(self, i, total):
-        idx = np.ones(total, dtype=np.bool)
+        idx = np.ones(total, dtype=bool)
         idx[i] = 0
         return idx
 

--- a/epidemix/vaccination.py
+++ b/epidemix/vaccination.py
@@ -122,8 +122,8 @@ class VacciModel(EpiModel):
         for i, idx_nodes in enumerate(subset):
             # Try each combination by changing its A matrix.
             A_temp = copy.deepcopy(A)
-            A_temp[idx_nodes.astype(np.int), :] = 0
-            A_temp[:, idx_nodes.astype(np.int)] = 0
+            A_temp[idx_nodes.astype(int), :] = 0
+            A_temp[:, idx_nodes.astype(int)] = 0
             # Get the corresponding graph using the A matrix.
             G_temp = self.set_graph(self.state_list,
                                     self.color_list,
@@ -138,7 +138,7 @@ class VacciModel(EpiModel):
             H_list[i] = H
 
         # Find the one combination with minimum HHI value.
-        idx = subset[np.argmin(H_list)].astype(np.int)
+        idx = subset[np.argmin(H_list)].astype(int)
         # Change the A matrix according to the selected nodes.
         A[idx, :] = 0
         A[:, idx] = 0


### PR DESCRIPTION
`numpy` types `np.bool `and `np.int` are deprecated. changed those to builtin `bool` and `int`